### PR TITLE
Logback upgrade example

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,36 @@
     <properties>
         <java.version>11</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <slf4j.version>1.7.30</slf4j.version>
+        <logback.version>1.2.3</logback.version>
     </properties>
+
+    <dependencies>
+        <dependency>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-core</artifactId>
+          <version>${logback.version}</version>
+        </dependency>
+
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+          <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+          <version>${logback.version}</version>
+        </dependency>
+
+        <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-engine</artifactId>
+          <version>5.6.0</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
 
     <dependencyManagement>
         <dependencies>
@@ -104,19 +133,20 @@
             <plugin>
                 <groupId>org.openrewrite.maven</groupId>
                 <artifactId>rewrite-maven-plugin</artifactId>
-                <version>4.16.0</version>
+                <version>4.17.0-SNAPSHOT</version>
                 <configuration>
                     <activeRecipes>
-                        <recipe>io.slugstack.oss.active</recipe>
+                        <!-- <recipe>io.slugstack.oss.active</recipe> -->
+                        <recipe>com.yourorg.LogbackInsight</recipe>
                     </activeRecipes>
                 </configuration>
-                <dependencies>
+                <!-- <dependencies>
                     <dependency>
                         <groupId>org.openrewrite.recipe</groupId>
                         <artifactId>rewrite-testing-frameworks</artifactId>
                         <version>1.15.1</version>
                     </dependency>
-                </dependencies>
+                </dependencies> -->
             </plugin>
         </plugins>
     </build>

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -1,10 +1,9 @@
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: io.slugstack.oss.active
+name: com.yourorg.LogbackInsight
+displayName: Find Logback Usage
 recipeList:
   - org.openrewrite.maven.UpgradeDependencyVersion:
-      groupId: junit
-      artifactId: junit
-      newVersion: 4.x
-      trustParent: true
-  - org.openrewrite.java.format.AutoFormat
+      groupId: ch.qos.logback
+      artifactId: logback-core
+      newVersion: latest.release


### PR DESCRIPTION
Do not merge, for example

Checking this out and running `./mvnw rewrite:run` will upgrade the pom.xml dependency for logback to 1.2.8